### PR TITLE
Update CentOS commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ chmod +x certbot-ubuntu.sh
 CentOS:
 
 ```bash
-wget https://raw.githubusercontent.com/cited/Certbot-Webmin-Module/master/scripts/certbot-ubuntu.sh
+wget https://raw.githubusercontent.com/cited/Certbot-Webmin-Module/master/scripts/certbot-centos.sh
 
-chmod +x certbot-ubuntu.sh
+chmod +x certbot-centos.sh
 
-./certbot-ubuntu.sh
+./certbot-centos.sh
 
 ```
 


### PR DESCRIPTION
The CentOS instructions were pointing to the ubuntu files. Fixed.